### PR TITLE
Support HTTP/1.0 proxies

### DIFF
--- a/packages/net/src/proxy/http/connect.ts
+++ b/packages/net/src/proxy/http/connect.ts
@@ -6,6 +6,7 @@ import { typed, u8, utf8 } from '@fuman/utils'
 import { buildConnectRequest } from './_protocol.js'
 import { HttpProxyConnectionError, type HttpProxySettings } from './types.js'
 
+const HTTP1_0_OK = /* #__PURE__ */ utf8.encoder.encode('HTTP/1.0 200')
 const HTTP1_1_OK = /* #__PURE__ */ utf8.encoder.encode('HTTP/1.1 200')
 const CR = /* #__PURE__ */ '\r'.charCodeAt(0)
 const LF = /* #__PURE__ */ '\n'.charCodeAt(0)
@@ -18,12 +19,12 @@ export async function performHttpProxyHandshake(
 ): Promise<void> {
     await writer.write(buildConnectRequest(proxy, destination))
 
-    // minimum valid response is "HTTP/1.1 200\r\n\r\n"
+    // minimum valid response is "HTTP/1.0 200\r\n\r\n"
     // we can safely read 12 bytes at first, validate them
     // and then read by 4 bytes at a time until we find \r\n\r\n
     const res1 = await read.async.exactly(reader, 12)
 
-    if (!typed.equal(res1, HTTP1_1_OK)) {
+    if (!typed.equal(res1, HTTP1_0_OK) || !typed.equal(res1, HTTP1_1_OK)) {
         throw new HttpProxyConnectionError(
             proxy,
             `Invalid HTTP response: ${utf8.decoder.decode(res1)}`,


### PR DESCRIPTION
Currently HTTP/1.0 proxies don't work:

```
2025-01-06T13:37:02.460Z [ERR] [mtproto] [USER n/a] unhandled error: HttpProxyConnectionError:
│ Error while connecting to 45.91.209.157:12582: Invalid HTTP response: HTTP/1.0 200
│     at performHttpProxyHandshake (file:///Users/arudnikov/Projects/crm/node_modules/.pnpm/@fuman+net@0.0.4/node_modules/@fuman/net/proxy/http/connect.js:12:11)
│     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
│     at async HttpProxyTcpTransport.connect (file:///Users/arudnikov/Projects/crm/node_modules/.pnpm/@mtcute+node@0.19.1/node_modules/@mtcute/node/utils/proxies.js:23:5)
│     at async #loop (file:///Users/arudnikov/Projects/crm/node_modules/.pnpm/@fuman+net@0.0.8/node_modules/@fuman/net/reconnection.js:60:28)
```