### PR TITLE
feat(fetch): add safeParse function

### DIFF
--- a/packages/fetch/src/addons/parse/_types.ts
+++ b/packages/fetch/src/addons/parse/_types.ts
@@ -1,11 +1,14 @@
 export interface FfetchTypeProvider {
     readonly schema: unknown
     readonly parsed: unknown
+    readonly safeParsed: unknown
 }
 
 export interface FfetchParser<TypeProvider extends FfetchTypeProvider> {
     readonly _provider: TypeProvider
     parse: (schema: unknown, value: unknown) => unknown | Promise<unknown>
+    safeParse: (schema: unknown, value: unknown) => unknown | Promise<unknown>
 }
 
 export type CallTypeProvider<TypeProvider extends FfetchTypeProvider, Schema> = (TypeProvider & { schema: Schema })['parsed']
+export type CallSafeTypeProvider<TypeProvider extends FfetchTypeProvider, Schema> = (TypeProvider & { schema: Schema })['safeParsed']

--- a/packages/fetch/src/addons/parse/adapters/valibot.test.ts
+++ b/packages/fetch/src/addons/parse/adapters/valibot.test.ts
@@ -21,6 +21,20 @@ describe('zod', () => {
         expect(res).toEqual('hello')
     })
 
+    it('should safely parse a type (pass)', async () => {
+        const parser = ffetchValibotAdapter()
+        const res = await parser.safeParse(v.string(), 'hello')
+
+        expect(res).toMatchObject({ success: true, output: 'hello' })
+    })
+
+    it('should safely parse a type (fail)', async () => {
+        const parser = ffetchValibotAdapter()
+        const res = await parser.safeParse(v.string(), 42)
+
+        expect(res).toMatchObject({ success: false })
+    })
+
     it('should work with ffetch (pass)', async () => {
         const fetch_ = vi.fn<typeof fetch>()
             .mockImplementation(async () => new Response('{"a": 42}'))

--- a/packages/fetch/src/addons/parse/adapters/valibot.ts
+++ b/packages/fetch/src/addons/parse/adapters/valibot.ts
@@ -1,13 +1,17 @@
-import type { AnySchema, BaseIssue, BaseSchema, BaseSchemaAsync, Config, InferOutput } from 'valibot'
+import type { AnySchema, BaseIssue, BaseSchema, BaseSchemaAsync, Config, InferOutput, SafeParseResult } from 'valibot'
 
 import type { FfetchParser, FfetchTypeProvider } from '../_types.js'
-import { parse, parseAsync } from 'valibot'
+import { parse, parseAsync, safeParse, safeParseAsync } from 'valibot'
 
 export interface ValibotTypeProvider extends FfetchTypeProvider {
     readonly parsed: this['schema'] extends (
         BaseSchema<unknown, unknown, BaseIssue<unknown>> |
         BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
     ) ? InferOutput<this['schema']> : never
+    readonly safeParsed: this['schema'] extends (
+        BaseSchema<unknown, unknown, BaseIssue<unknown>> |
+        BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+    ) ? SafeParseResult<this['schema']> : never
 }
 
 export function ffetchValibotAdapter(
@@ -21,9 +25,17 @@ export function ffetchValibotAdapter(
         : function (schema: unknown, value: unknown): unknown {
             return parse(schema as AnySchema, value, rest)
         }
+    const safeParser = async
+        ? async function (schema: unknown, value: unknown): Promise<unknown> {
+            return safeParseAsync(schema as AnySchema, value, rest)
+        }
+        : function (schema: unknown, value: unknown): unknown {
+            return safeParse(schema as AnySchema, value, rest)
+        }
 
     return {
         _provider,
         parse: parser,
+        safeParse: safeParser,
     }
 }

--- a/packages/fetch/src/addons/parse/adapters/valita.test.ts
+++ b/packages/fetch/src/addons/parse/adapters/valita.test.ts
@@ -14,6 +14,20 @@ describe('valita', () => {
         expect(res).toEqual('hello')
     })
 
+    it('should safely parse a type (pass)', async () => {
+        const parser = ffetchValitaAdapter()
+        const res = await parser.safeParse(v.string(), 'hello')
+
+        expect(res).toMatchObject({ ok: true, value: 'hello' })
+    })
+
+    it('should safely parse a type (fail)', async () => {
+        const parser = ffetchValitaAdapter()
+        const res = await parser.safeParse(v.string(), 42)
+
+        expect(res).toMatchObject({ ok: false })
+    })
+
     it('should work with ffetch (pass)', async () => {
         const fetch_ = vi.fn<typeof fetch>()
             .mockImplementation(async () => new Response('{"a": 42}'))

--- a/packages/fetch/src/addons/parse/adapters/valita.ts
+++ b/packages/fetch/src/addons/parse/adapters/valita.ts
@@ -4,6 +4,7 @@ import type { FfetchParser, FfetchTypeProvider } from '../_types.js'
 
 export interface ValitaTypeProvider extends FfetchTypeProvider {
     readonly parsed: this['schema'] extends v.Type<any> ? v.Infer<this['schema']> : never
+    readonly safeParsed: this['schema'] extends v.Type<any> ? v.ValitaResult<v.Infer<this['schema']>> : never
 }
 
 type ParseOptions = NonNullable<Parameters<v.Type<any>['parse']>[1]>
@@ -15,6 +16,9 @@ export function ffetchValitaAdapter(options?: ParseOptions): FfetchParser<Valita
         _provider,
         parse(schema: unknown, value: unknown): unknown {
             return (schema as v.Type<any>).parse(value, options)
+        },
+        safeParse(schema: unknown, value: unknown): unknown {
+            return (schema as v.Type<any>).try(value, options)
         },
     }
 }

--- a/packages/fetch/src/addons/parse/adapters/yup.test.ts
+++ b/packages/fetch/src/addons/parse/adapters/yup.test.ts
@@ -14,6 +14,20 @@ describe('zod', () => {
         expect(res).toEqual('hello')
     })
 
+    it('should safely parse a type (pass)', async () => {
+        const parser = ffetchYupAdapter()
+        const res = await parser.safeParse(y.string(), 'hello')
+
+        expect(res).toMatchObject({ success: true, data: 'hello' })
+    })
+
+    it('should safely parse a type (fail)', async () => {
+        const parser = ffetchYupAdapter({ action: 'validate', options: { strict: true } })
+        const res = await parser.safeParse(y.string(), 42)
+
+        expect(res).toMatchObject({ success: false })
+    })
+
     it('should work with ffetch (pass)', async () => {
         const fetch_ = vi.fn<typeof fetch>()
             .mockImplementation(async () => new Response('{"a": 42}'))

--- a/packages/fetch/src/addons/parse/adapters/yup.ts
+++ b/packages/fetch/src/addons/parse/adapters/yup.ts
@@ -1,9 +1,14 @@
-import type { CastOptions, InferType, ISchema, ValidateOptions } from 'yup'
+import type { CastOptions, InferType, ISchema, ValidateOptions, ValidationError } from 'yup'
 
 import type { FfetchParser, FfetchTypeProvider } from '../_types.js'
 
+type YupSafeParseResult<R> =
+    | { success: true, data: R }
+    | { success: false, error: ValidationError }
+
 export interface YupTypeProvider extends FfetchTypeProvider {
     readonly parsed: this['schema'] extends ISchema<any, any> ? InferType<this['schema']> : never
+    readonly safeParsed: this['schema'] extends ISchema<any, any> ? YupSafeParseResult<InferType<this['schema']>> : never
 }
 
 export type FfetchYupAdapterOptions =
@@ -16,15 +21,33 @@ export function ffetchYupAdapter({
 }: FfetchYupAdapterOptions = { action: 'validate' }): FfetchParser<YupTypeProvider> {
     const _provider = null as unknown as YupTypeProvider
     const parse = action === 'cast'
-        ? async function (schema: unknown, value: unknown): Promise<unknown> {
+        ? function (schema: unknown, value: unknown): unknown {
             return (schema as ISchema<any, any>).cast(value, options)
         }
-        : function (schema: unknown, value: unknown): unknown {
+        : async function (schema: unknown, value: unknown): Promise<unknown> {
             return (schema as ISchema<any, any>).validate(value, options)
+        }
+    const safeParse = action === 'cast'
+        ? function (schema: unknown, value: unknown): unknown {
+            try {
+                const data = (schema as ISchema<any, any>).cast(value, options)
+                return { success: true, data }
+            } catch (e) {
+                return { success: false, error: e }
+            }
+        }
+        : async function (schema: unknown, value: unknown): Promise<unknown> {
+            try {
+                const data = await (schema as ISchema<any, any>).validate(value, options)
+                return { success: true, data }
+            } catch (e) {
+                return { success: false, error: e }
+            }
         }
 
     return {
         _provider,
         parse,
+        safeParse,
     }
 }

--- a/packages/fetch/src/addons/parse/adapters/yup.ts
+++ b/packages/fetch/src/addons/parse/adapters/yup.ts
@@ -30,7 +30,7 @@ export function ffetchYupAdapter({
     const safeParse = action === 'cast'
         ? function (schema: unknown, value: unknown): unknown {
             try {
-                const data = (schema as ISchema<any, any>).cast(value, options)
+                const data: unknown = (schema as ISchema<any, any>).cast(value, options)
                 return { success: true, data }
             } catch (e) {
                 return { success: false, error: e }
@@ -38,7 +38,7 @@ export function ffetchYupAdapter({
         }
         : async function (schema: unknown, value: unknown): Promise<unknown> {
             try {
-                const data = await (schema as ISchema<any, any>).validate(value, options)
+                const data: unknown = await (schema as ISchema<any, any>).validate(value, options)
                 return { success: true, data }
             } catch (e) {
                 return { success: false, error: e }

--- a/packages/fetch/src/addons/parse/adapters/zod.test.ts
+++ b/packages/fetch/src/addons/parse/adapters/zod.test.ts
@@ -21,6 +21,20 @@ describe('zod', () => {
         expect(res).toEqual('hello')
     })
 
+    it('should safely parse a type (pass)', async () => {
+        const parser = ffetchZodAdapter()
+        const res = await parser.safeParse(z.string(), 'hello')
+
+        expect(res).toMatchObject({ success: true, data: 'hello' })
+    })
+
+    it('should safely parse a type (fail)', async () => {
+        const parser = ffetchZodAdapter()
+        const res = await parser.safeParse(z.string(), 42)
+
+        expect(res).toMatchObject({ success: false })
+    })
+
     it('should work with ffetch (pass)', async () => {
         const fetch_ = vi.fn<typeof fetch>()
             .mockImplementation(async () => new Response('{"a": 42}'))

--- a/packages/fetch/src/addons/parse/adapters/zod.ts
+++ b/packages/fetch/src/addons/parse/adapters/zod.ts
@@ -1,9 +1,10 @@
-import type { ParseParams, z } from 'zod'
+import type { ParseParams, SafeParseReturnType, z } from 'zod'
 
 import type { FfetchParser, FfetchTypeProvider } from '../_types.js'
 
 export interface ZodTypeProvider extends FfetchTypeProvider {
     readonly parsed: this['schema'] extends z.ZodTypeAny ? z.infer<this['schema']> : never
+    readonly safeParsed: this['schema'] extends z.ZodTypeAny ? SafeParseReturnType<this['schema'], z.infer<this['schema']>> : never
 }
 
 export function ffetchZodAdapter({ async, ...rest }: Partial<ParseParams> = {}): FfetchParser<ZodTypeProvider> {
@@ -15,9 +16,17 @@ export function ffetchZodAdapter({ async, ...rest }: Partial<ParseParams> = {}):
         : function (schema: unknown, value: unknown): unknown {
             return (schema as z.ZodTypeAny).parse(value, rest)
         }
+    const safeParse = async
+        ? async function (schema: unknown, value: unknown): Promise<z.SafeParseReturnType<unknown, unknown>> {
+            return (schema as z.ZodTypeAny).safeParseAsync(value, rest)
+        }
+        : function (schema: unknown, value: unknown): z.SafeParseReturnType<unknown, unknown> {
+            return (schema as z.ZodTypeAny).safeParse(value, rest)
+        }
 
     return {
         _provider,
         parse,
+        safeParse,
     }
 }

--- a/packages/fetch/src/addons/parse/addon.ts
+++ b/packages/fetch/src/addons/parse/addon.ts
@@ -1,7 +1,7 @@
 import type { FfetchResult } from '../../ffetch.js'
 import type { FfetchAddon } from '../types.js'
 
-import type { CallTypeProvider, FfetchParser, FfetchTypeProvider } from './_types.js'
+import type { CallSafeTypeProvider, CallTypeProvider, FfetchParser, FfetchTypeProvider } from './_types.js'
 
 export { FfetchParser, FfetchTypeProvider }
 
@@ -11,12 +11,16 @@ export function parser<TypeProvider extends FfetchTypeProvider>(
         object,
         {
             parsedJson: <Schema>(schema: Schema) => Promise<CallTypeProvider<TypeProvider, Schema>>
+            safelyParsedJson: <Schema>(schema: Schema) => Promise<CallSafeTypeProvider<TypeProvider, Schema>>
         }
     > {
     return {
         response: {
             async parsedJson(this: FfetchResult, schema: unknown) {
                 return parser.parse(schema, await this.json())
+            },
+            async safelyParsedJson(this: FfetchResult, schema: unknown) {
+                return parser.safeParse(schema, await this.json())
             },
         },
     }


### PR DESCRIPTION
Almost all supported type parsers (`zod`, `valibot`, `valita`) have two options for validating: throwing errors and returning a Result union object. Currently `@fuman/fetch` only provides the former option, which is harder to use if you want to implement custom error handling or stick to explicit flow control.

This PR addresses this issue and adds `safeParse` function to `FfetchTypeProvider` that uses the Result-based validating. `yup` sadly doesn't have a way to execute validation without throwing, so a simple try-catch wrapper was implemented.