### PR TITLE
fix(fetch): bind globalThis when using global fetch

### DIFF
--- a/packages/fetch/src/ffetch.ts
+++ b/packages/fetch/src/ffetch.ts
@@ -297,7 +297,7 @@ export function createFfetch<
     baseOptions: FfetchBaseOptions<Addons> & Combined['request'] = {},
 ): Ffetch<Combined['request'], Combined['response']> {
     const captureStackTrace = baseOptions.captureStackTrace ?? true
-    const baseFetch = baseOptions.fetch ?? fetch
+    const baseFetch = baseOptions.fetch ?? globalThis.fetch?.bind(globalThis)
     const wrappedFetch: FetchLike = baseOptions.middlewares !== undefined && baseOptions.middlewares.length > 0 ? composeMiddlewares(baseOptions.middlewares, baseFetch) : baseFetch
     const addons = baseOptions.addons ?? []
 


### PR DESCRIPTION
Currently when base fetch function is called, its `this` value is set to an instance of `FfetchResultImpl` which results in an illegal invocation error in browsers that require `this` to be an instance of Window when `fetch` is called. This fix binds `globalThis` as `this` when the default global fetch function is used.