### PR TITLE
fix: path to config file

### DIFF
--- a/packages/build/src/misc/_config.ts
+++ b/packages/build/src/misc/_config.ts
@@ -1,11 +1,13 @@
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 const CONFIG_NAME = 'build.config.js'
 
 export async function loadBuildConfig<T>(packageRoot: string): Promise<T | undefined> {
   try {
+    const filePath = pathToFileURL(join(packageRoot, CONFIG_NAME)).href
     // eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-member-access
-    const mod = (await import(join(packageRoot, CONFIG_NAME))).default
+    const mod = (await import(filePath)).default
     if (typeof mod === 'function') {
       // eslint-disable-next-line ts/no-unsafe-call
       return mod() as T


### PR DESCRIPTION
I get an error when installing dependencies

```postinstall$ tsx packages/build/src/cli/main.ts lint
│ Error: Could not load build.config.js
│     at loadBuildConfig (**\fuman\packages\build\src\misc\_config.ts:19:13)
│     at async loadConfig (**\fuman\packages\build\src\cli\commands\_utils.ts:17:18)
│     at async Object.handler (**\fuman\packages\build\src\cli\commands\lint\index.ts:24:21)
│     at async Module.run (**\fuman\node_modules\.pnpm\@drizzle-team+brocli@0.10.2\node_modules\@drizzle-team\src\command-core.ts:893:4)
│     at async <anonymous> (**\fuman\packages\build\src\cli\main.ts:17:1) {
│   [cause]: Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'f:'
│       at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:249:11)
│       at defaultLoad (node:internal/modules/esm/load:130:3)
│       at nextLoad (node:internal/modules/esm/hooks:868:28)
│       at load (file:///**/fuman/node_modules/.pnpm/tsx@4.16.5/node_modules/tsx/dist/esm/index.mjs?1754641431532:2:1768)
│       at nextLoad (node:internal/modules/esm/hooks:868:28)
│       at Hooks.load (node:internal/modules/esm/hooks:451:26)
│       at handleMessage (node:internal/modules/esm/worker:196:24)
│       at Immediate.checkForMessages (node:internal/modules/esm/worker:138:28)
│       at process.processImmediate (node:internal/timers:483:21) {
│     code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
│   }
│ }```